### PR TITLE
fix: :bug: vspheremachine API down conversion from v1beta1 to v1alpha4

### DIFF
--- a/apis/v1alpha4/vspheremachine_conversion.go
+++ b/apis/v1alpha4/vspheremachine_conversion.go
@@ -53,7 +53,16 @@ func (src *VSphereMachine) ConvertTo(dstRaw conversion.Hub) error {
 // ConvertFrom converts from the Hub version (v1beta1) to this VSphereMachine.
 func (dst *VSphereMachine) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*infrav1beta1.VSphereMachine)
-	return Convert_v1beta1_VSphereMachine_To_v1alpha4_VSphereMachine(src, dst, nil)
+	if err := Convert_v1beta1_VSphereMachine_To_v1alpha4_VSphereMachine(src, dst, nil); err != nil {
+		return err
+	}
+
+	// Preserve Hub data on down-conversion except for metadata
+	if err := utilconversion.MarshalData(src, dst); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ConvertTo converts this VSphereMachineList to the Hub version (v1beta1).


### PR DESCRIPTION
**What this PR does / why we need it**:
The downconversion from v1beta1 to v1alpha4 fails with following error
```
E0410 14:16:09.642122       1 controller.go:324] "Reconciler error" err="failed to update Machines: failed to update InfrastructureMachine vena-ref/ref-20273-test-k8s-md-0-hlq9j-2s64b: failed to update vena-ref/ref-20273-test-k8s-md-0-hlq9j-2s64b: failed to apply VSphereMachine vena-ref/ref-20273-test-k8s-md-0-hlq9j-2s64b: failed to prune fields: failed add back owned items: failed to convert pruned object at version infrastructure.cluster.x-k8s.io/v1beta1: conversion webhook for infrastructure.cluster.x-k8s.io/v1alpha4, Kind=VSphereMachine returned invalid metadata: invalid metadata of type <nil> in input object" controller="machineset" controllerGroup="cluster.x-k8s.io" controllerKind="MachineSet" MachineSet="vena-ref/ref-20273-test-k8s-md-0-674b864c47x894lx" namespace="vena-ref" name="ref-20273-test-k8s-md-0-674b864c47x894lx" reconcileID=a2025937-9cb7-4698-bfd9-1bb280660619
```
related upstream fix: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2740
The upstream fix touches a lot of files and created against `v1.9.0`. we like to just patch the fix that affects downgrade of `vsphereMachine`

**Testing steps**
This fix is tested manually.
Create a cluster using DKP 2.7(CAPV 1.8.1) and IPAM provider.
in following examples cluster name is: `capv-ipam-dkp-2.7`
1. Follow steps 1-3 to install metal3 controller and ipam adaptor: https://eng.d2iq.com/blog/capi-vsphere-capv-nodes-with-predefined-ip-ranges/#steps-to-deploy-capv-with-ipam
2. create IP pool 
```
apiVersion: ipam.metal3.io/v1alpha1
kind: IPPool
metadata:
  name: capv-ipam-dkp-2.7-pool
  labels:
    cluster.x-k8s.io/network-name: VMs
spec:
  clusterName: capv-ipam-dkp-2.7
  namePrefix: capv-ipam-dkp-2.7-prov
  pools:
    - start: 10.128.6.160
      end: 10.128.6.170
      prefix: 27
      gateway: 10.128.255.254
  prefix: 27
  gateway: 10.128.255.254
  dnsServers: [8.8.8.8,8.8.4.4]
```
4.  create cluster yaml
```
dkp-2.7/dkp create cluster vsphere --cluster-name=capv-ipam-dkp-2.7 \
--network=VMs \
--control-plane-endpoint-host=10.128.25.190 \
--data-center=dc1 \
--data-store=ci-konvoy \
--folder=/dc1/vm/ci/ci-konvoy \
--server=vcenter.ca1.ksphere-platform.d2iq.cloud \
--ssh-public-key-file=/path/to/key.pub \
--resource-pool=ci-konvoy \
--vm-template=konvoy-rocky-91-release-1.27.6-20231017200626 \
--virtual-ip-interface=eth0 \
--registry-mirror-url https://registry-1.docker.io \
--registry-mirror-username ${DOCKER_HUB_USERNAME} \
--registry-mirror-password ${DOCKER_HUB_PASSWORD} \
--dry-run \
-o yaml > capv-ipam-dkp-2.7.yaml
```
5. update `VSphereMachineTemplate` for the nodepool and add label `cluster.x-k8s.io/ip-pool-name: capv-ipam-dkp-2.7-pool`

7.  create cluster `kubectl create -f capv-ipam-dkp-2.7.yaml`

Observe the above errors in `capi-controller` pod for the VMs of the nodepool.

8. Create new CAPV image with fix: `make docker-build-all`
9. load it to the kind bootstrap cluster: `kind load docker-image mesosphere/cluster-api-vsphere-controller-amd64:dev --name=konvoy-capi-bootstrapper` and restart `capv-controller` pod.
10. Either wait for next reconciliation or delete `capi-controller` to check if the Machines get reconciled without any error. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
