### PR TITLE
ci: GHA workflow to release image to ghcr.io

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -1,0 +1,26 @@
+name: Release to ghcr.io
+on:
+  push:
+    tags:
+      - "*-d2iq.*"
+
+# Because variables are not exported, they are not visible by child processes, e.g. make
+env:
+  registry: ghcr.io/mesosphere
+
+jobs:
+  release-image:
+    name: Release
+    runs-on:
+      - ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push container image
+        run: |
+          make release-ghcr

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
 PROD_REGISTRY ?= registry.k8s.io/cluster-api-vsphere
 
 STAGING_REGISTRY ?= gcr.io/k8s-staging-capi-vsphere
+GHCR_REGISTRY ?= ghcr.io/mesosphere/cluster-api-provider-vsphere
 STAGING_BUCKET ?= artifacts.k8s-staging-capi-vsphere.appspot.com
 
 # core
@@ -499,7 +500,7 @@ e2e: $(GINKGO) $(KUSTOMIZE) $(KIND) $(GOVC) ## Run e2e tests
 ##@ release:
 
 ## latest git tag for the commit, e.g., v0.3.10
-RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
+RELEASE_TAG ?= $(shell git describe --tags --always 2>/dev/null)
 ifneq (,$(findstring -,$(RELEASE_TAG)))
     PRE_RELEASE=true
 endif
@@ -606,6 +607,11 @@ generate-flavors: $(FLAVOR_DIR)
 .PHONY: release-staging
 release-staging: ## Build and push container images to the staging registry
 	REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-build-all docker-push-all release-alias-tag
+
+.PHONY: release-ghcr
+release-ghcr: ## Build and push container images to the ghcr.io
+	REGISTRY=$(GHCR_REGISTRY) TAG=$(RELEASE_TAG) $(MAKE) docker-build-all docker-push-all
+
 
 .PHONY: release-alias-tag
 release-alias-tag: ## Add the release alias tag to the last build tag


### PR DESCRIPTION

**What this PR does / why we need it**:
- github actions workflow to push CAPV image to ghcr.io
- Tested the workflow successfully: https://github.com/mesosphere/cluster-api-provider-vsphere/actions/runs/8712421682/job/23898693701 to push image `ghcr.io/mesosphere/cluster-api-provider-vsphere/cluster-api-vsphere-controller:t1.8.0-d2iq.test.dev` 
