### PR TITLE
ci: ensure provider templates have correct image URL

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
           go-version: ${{ env.go_version }}
       - name: generate release artifacts
         run: |
-          make release
+          PROD_REGISTRY="ghcr.io/mesosphere/cluster-api-provider-vsphere" make release
       - name: generate release notes
         run: |
           make generate-release-notes


### PR DESCRIPTION
Ensure that `infrastructure-components.yaml` refers to `ghcr.io/mesosphere/cluster-api-provider-vsphere/cluster-api-vsphere-controller:v1.8.9-d2iq.0`. 
I only realized it after making a release. 